### PR TITLE
chore: swagger docs 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,10 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// SWAGGER
+	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.8.0'
+	implementation 'org.jetbrains.kotlin:kotlin-reflect:1.9.21'
 }
 
 tasks.named('test') {

--- a/src/main/java/spot/fakeApi/global/config/SwaggerConfig.java
+++ b/src/main/java/spot/fakeApi/global/config/SwaggerConfig.java
@@ -1,0 +1,43 @@
+package spot.fakeApi.global.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public GroupedOpenApi api() {
+        return GroupedOpenApi.builder()
+                .group("all-api")
+                .pathsToMatch("/**")
+                .build();
+    }
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .title("SPOT FAKE-API")
+                .version("v1.0.1")
+                .description(
+                        "<div style='text-align:center;'>"
+                                + "<h2>WELCOME TO SPOT FAKE-API SERVER</h2>"
+                                + "</div>"
+                                + "<style>"
+                                + "h1, h2 { color: #2c3e50; font-family: Arial, sans-serif; }"
+                                + "p { font-size: 14px; }"
+                                + "</style>"
+                );
+
+        return new OpenAPI()
+                .addServersItem(new Server().url("https://ilmatch.net")
+                        .description("Default Server URL"))
+                .addServersItem(new Server().url("http://localhost:8080")
+                        .description("Local Development Server"))
+                .info(info);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,19 @@ spring.jwt.refresh.token=86400000
 spring.jwt.secretKey=dfafjdsldfkldsjfsoifjsdfjsdlkfjskadfjsdoifjsadlfjksdfasdfasdfasdfsadsdf
 
 fake.api.redirect.domain=http://localhost:8080
+
+springdoc.show-login-endpoint=true
+springdoc.api-docs.enabled=true
+springdoc.api-docs.path= /v3/api-docs
+springdoc.swagger-ui.enabled=true
+springdoc.swagger-ui.path= /api/swagger-ui.html
+springdoc.swagger-ui.tags-sorter=alpha
+springdoc.swagger-ui.display-request-duration=true
+springdoc.swagger-ui.operations-sorter=alpha
+springdoc.swagger-ui.disable-swagger-default-url=true
+springdoc.swagger-ui.urls[0].name=Default Server URL
+springdoc.swagger-ui.urls[0].url=/v3/api-docs
+springdoc.default-produces-media-type=application/json
+
+logging.level.org.springframework.web= ERROR
+logging.level.root= INFO


### PR DESCRIPTION
swagger 추가했습니다..!

결제사용은

결제 준비(/fake-api/pay/ready)를 입력하고 나온 반환 값에서
<img width="787" alt="스크린샷 2025-03-20 오전 9 24 16" src="https://github.com/user-attachments/assets/8fadd2fe-fa57-4b8e-817d-d2709455d4e3" />
pcUrl혹은 mobileUrl에 get 요청만 하면 pgToken이 반환되게 하였습니다.

그 후,
결제 승인(/fake-api/pay/approve)에 ready에서 나온 tid값과 pgToken값을 입력하고 요청을 보내면 사용하실 수 있습니다.

취소에서는 위에서 결제 준비시 반환된 tid값만 변경하시면 됩니다.